### PR TITLE
Specify the required faraday version (~> 2.0)

### DIFF
--- a/mapboxkit.gemspec
+++ b/mapboxkit.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday'
+  spec.add_dependency 'faraday', '~> 2.0'
   spec.add_dependency 'faraday-multipart'
 
   spec.add_development_dependency 'dotenv'


### PR DESCRIPTION
Doesn't work with old faraday gem. So add version requirement for faraday