### PR TITLE
Unuse Faraday::Request::Json::MIME_TYPE

### DIFF
--- a/lib/mapboxkit/connection.rb
+++ b/lib/mapboxkit/connection.rb
@@ -8,7 +8,7 @@ module Mapboxkit
     # Network layer for API clients.
     #
     module Connection
-      DEFAULT_REQUEST_CONTENT_TYPE = Faraday::Request::Json::MIME_TYPE
+      DEFAULT_REQUEST_CONTENT_TYPE = 'application/json'
 
       def get(url, params = {})
         response = connection.get(url, params, content_type: nil)


### PR DESCRIPTION
Faraday::Request::Json::MIME_TYPE is not defined at faraday v1. So not reuse the constant.
