### PR TITLE
Specify processing content_type with JSON response to support faraday v1

### DIFF
--- a/lib/mapboxkit/connection.rb
+++ b/lib/mapboxkit/connection.rb
@@ -53,7 +53,7 @@ module Mapboxkit
 
             faraday.response(:logger) if ENV['VERBOSE'] == '1'
 
-            faraday.response(:json)
+            faraday.response(:json, content_type: %r{^application/(vnd\..+\+)?json$})
 
             faraday.response(:raise_error)
 


### PR DESCRIPTION
Faraday v2's json response middleware parses responses only if Content-type is json.

However, Faraday v1's json response middleware parses responses regardless of Content-type by default.

This results in an error when responding to a non-JSON response.

To avoid this problem, specify the Content-type explicitly during JSON parsing.